### PR TITLE
Message part of log4net call should be sent to Sentry & appender should support multiple DSNs

### DIFF
--- a/src/app/SharpRaven.Log4Net/SentryAppender.cs
+++ b/src/app/SharpRaven.Log4Net/SentryAppender.cs
@@ -21,7 +21,7 @@ namespace SharpRaven.Log4Net
 
     public class SentryAppender : AppenderSkeleton
     {
-        protected static IRavenClient RavenClient;
+        protected IRavenClient RavenClient;
         public string DSN { get; set; }
         public string Logger { get; set; }
         private readonly IList<SentryTag> tagLayouts = new List<SentryTag>();

--- a/src/tests/SharpRaven.Log4Net.Tests.Console/App.config
+++ b/src/tests/SharpRaven.Log4Net.Tests.Console/App.config
@@ -4,6 +4,10 @@
 		<section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
 	</configSections>
 
+	<appSettings>
+		<add key="log4net.Internal.Debug" value="true"/>		
+	</appSettings>
+	
 	<startup>
 		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
 	</startup>
@@ -16,8 +20,9 @@
 			</layout>
 		</appender>
 
-		<appender name="SentryAppender" type="SharpRaven.Log4Net.SentryAppender, SharpRaven.Log4Net">
-			<DSN value="https://7d6466e66155431495bdb4036ba9a04b:4c1cfeab7ebd4c1cb9e18008173a3630@app.getsentry.com/3739" />
+		<!-- Please provide a DSN to test with -->
+		<appender name="SentryAppenderForRoot" type="SharpRaven.Log4Net.SentryAppender, SharpRaven.Log4Net">
+			<DSN value="..." />
 			<Logger value="SharpRaven.Log4Net.Tests.Console" />
 			<threshold value="ERROR" />
 			<layout type="log4net.Layout.PatternLayout">
@@ -25,11 +30,26 @@
 			</layout>
 		</appender>
 
+			<!-- Please provide a second DSN to test with -->
+			<appender name="SentryAppenderForCustomLog" type="SharpRaven.Log4Net.SentryAppender, SharpRaven.Log4Net">
+			<DSN value="...." />
+			<Logger value="Custom Log" />
+			<threshold value="ERROR" />
+			<layout type="log4net.Layout.PatternLayout">
+				<conversionPattern value="%5level - %message%newline" />
+			</layout>
+		</appender>
+
+
 		<root>
 			<level value="INFO" />
+			<appender-ref ref="SentryAppenderForRoot" />
 			<appender-ref ref="ConsoleAppender" />
-			<appender-ref ref="SentryAppender" />
 		</root>
+
+		<logger name="CustomLog" additivity="false">
+			<appender-ref ref="SentryAppenderForCustomLog" />
+		</logger>
 	</log4net>
 
 	<runtime>

--- a/src/tests/SharpRaven.Log4Net.Tests.Console/Program.cs
+++ b/src/tests/SharpRaven.Log4Net.Tests.Console/Program.cs
@@ -12,19 +12,58 @@ namespace SharpRaven.Log4Net.Tests.Console {
 	class Program {
 		static void Main(string[] args)
 		{
+			/*
+			 * This project has some tests for which you'll need to add your own DSN to check
+			 * that the result is as you expect it.
+			 */
+
+
 			XmlConfigurator.Configure();
-			var log = LogManager.GetLogger(typeof (Program));
+
+			TestSingleAlert();
+			TestTwoLoggers();
+
+			System.Console.WriteLine("Press a key to finish");
+			System.Console.ReadKey();
+		}
+
+
+		private static void TestSingleAlert()
+		{
+			var log = LogManager.GetLogger(typeof(Program));
+
+			log.ErrorFormat("foo {0}", "123");
+
+			try {
+				throw new ApplicationException("Testing logging from console app");
+			} catch (ApplicationException aEx) {
+				// Things to check:
+				// - Did the event arrive?
+				// - Are any command line parameters added to the event?
+				// - Did the "Custom message" appear in the event on Sentry?
+				log.Error("Custom message", aEx);
+			}
+		}
+
+
+		private static void TestTwoLoggers()
+		{
+			var log1 = LogManager.GetLogger(typeof (Program));
+			var log2 = LogManager.GetLogger("CustomLog");
 
 			try
 			{
-				throw new ApplicationException("Testing logging from console app");
+				throw new ApplicationException("Testing two loggers");
 			}
 			catch (ApplicationException aEx)
 			{
-				log.Error("Custom message", aEx);
+				// Things to check:
+				// - Did two events arrive in different projects in Sentry?
+				log1.Error("Program log", aEx);
+				log2.Error("Custom log", aEx);
 			}
-			
-
 		}
+
+
 	}
 }

--- a/src/tests/SharpRaven.Log4Net.Tests/SentryAppenderTests.cs
+++ b/src/tests/SharpRaven.Log4Net.Tests/SentryAppenderTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using log4net.Core;
+using log4net.Repository;
+
+using Moq;
+
+using NUnit.Framework;
+
+using SharpRaven.Data;
+
+namespace SharpRaven.Log4Net.Tests {
+	[TestFixture]
+	public class SentryAppenderTests {
+
+		#region Derived test class
+		/// <summary>Derived SentryAppender that gives us access to the raven client so that we can test</summary>
+		public class SentryAppenderUnderTest : SentryAppender
+		{
+			public void SetRavenClient(IRavenClient ravenClient)
+			{
+				RavenClient = ravenClient;
+			}
+
+			public void DoAppendUnderTest(LoggingEvent loggingEvent)
+			{
+				DoAppend(loggingEvent);
+			}
+		}
+		#endregion
+
+		private Mock<IRavenClient> _ravenClientMock;
+		private Mock<ILoggerRepository> _loggerRepositoryMock;
+		private SentryAppenderUnderTest _sentryAppender;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_ravenClientMock = new Mock<IRavenClient>();
+			_loggerRepositoryMock = new Mock<ILoggerRepository>();
+
+			_sentryAppender = new SentryAppenderUnderTest();
+			_sentryAppender.SetRavenClient(_ravenClientMock.Object);
+		}
+
+
+		[Test]
+		public void Append_WithExceptionAndMessage() {
+			var exception = new Exception("ExceptionAndMessage");
+
+			_sentryAppender.DoAppendUnderTest(CreateLoggingEvent("Custom message", exception));
+
+			_ravenClientMock.Verify(
+				rc => rc.CaptureException(It.Is<Exception>(e => Object.ReferenceEquals(e, exception)),
+					It.Is<SentryMessage>(sm => sm.Message == "Custom message"),
+					It.IsAny<ErrorLevel>(),
+					It.IsAny<IDictionary<string, string>>(),
+					It.IsAny<object>()),
+				Times.Once);
+		}
+
+		[Test]
+		public void Append_WithJustException() {
+			var exception = new Exception("JustException");
+
+			_sentryAppender.DoAppendUnderTest(CreateLoggingEvent(exception));
+
+			_ravenClientMock.Verify(
+				rc => rc.CaptureException(It.Is<Exception>(e => Object.ReferenceEquals(e, exception)),
+					It.Is<SentryMessage>(sm => sm == null),
+					It.IsAny<ErrorLevel>(),
+					It.IsAny<IDictionary<string, string>>(),
+					It.IsAny<object>()),
+				Times.Once);
+		}
+
+
+		private LoggingEvent CreateLoggingEvent(object message, Exception exception = null)
+		{
+			return new LoggingEvent(typeof(SentryAppenderTests),
+				_loggerRepositoryMock.Object,
+				"test",
+				Level.Error,
+				message,
+				exception);
+		}
+
+
+	}
+}

--- a/src/tests/SharpRaven.Log4Net.Tests/SharpRaven.Log4Net.Tests.csproj
+++ b/src/tests/SharpRaven.Log4Net.Tests/SharpRaven.Log4Net.Tests.csproj
@@ -36,6 +36,10 @@
     <Reference Include="log4net">
       <HintPath>..\..\..\packages\log4net.2.0.5\lib\net40-full\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.6\lib\net40\Newtonsoft.Json.dll</HintPath>
@@ -55,6 +59,7 @@
     <Compile Include="..\..\..\build\VersionInfo.cs" Condition="Exists('..\..\..\build\VersionInfo.cs')">
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="SentryAppenderTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config">

--- a/src/tests/SharpRaven.Log4Net.Tests/packages.config
+++ b/src/tests/SharpRaven.Log4Net.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.5" targetFramework="net40" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
   <package id="SharpRaven" version="1.5.1" targetFramework="net40" />


### PR DESCRIPTION
At the moment if an exception is logged then the message passed into log4net is just lost.

I've altered it so that if you log just an exception that's logged as it is currently (i.e. with the exception message) but if you pass a message into log4net then that should be used as the message in Sentry.

I think this is a sensible change:
- if the user is passing a message they would expect that to be logged.
- the exception message is still available in the stack trace on Sentry.
- roll up should still occur on the stack trace.
- no change to the behaviour when there's no stack trace.

I've also made some tweaks to allow unit testing. It's not the cleanest test setup but we are constrained somewhat by log4net. I've also tested that it works against my own Sentry subscription.

As always, happy to make changes if you think I've gone in the wrong direction here (should this behaviour be controlled by configuration?).
